### PR TITLE
Handle Agent Builder auth quirks more robustly

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Replace:
 - `your-app-name.onrender.com` with your Render URL
 - `<YOUR_GENERECT_API_KEY>` with your Generect API key
 
+### OpenAI Agent Builder
+
+When adding the remote MCP server in Agent Builder, choose **Bearer Token** authentication and paste **only** your raw Generect API key (without additional `Bearer` or `Token` prefixes). The server will normalize whatever the builder sends, so providing the plain key avoids duplicated prefixes that can cause authentication failures.
+
 ### Claude API (MCP Connector)
 
 ```bash


### PR DESCRIPTION
## Summary
- strip repeated bearer/token prefixes when normalizing Authorization headers during MCP initialization and tool execution
- document how to supply the Generect API key when configuring the remote MCP in OpenAI Agent Builder
- accept initialize requests that only specify the method name so Agent Builder can establish a session even when it omits protocol metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e68af25168832f8103f1e75b6771c5