### PR TITLE
Add MCP request/response logging and fix filter-error masking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=build /app/dist ./dist
 
 ENV NODE_ENV=production \
     GENERECT_API_BASE=https://api.generect.com \
-    GENERECT_TIMEOUT_MS=60000
+    GENERECT_TIMEOUT_MS=300000
 
 EXPOSE 3000
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For local development or when OAuth is not needed:
 ```bash
 GENERECT_API_BASE=https://api.generect.com
 GENERECT_API_KEY=Token <api-key>
-GENERECT_TIMEOUT_MS=60000
+GENERECT_TIMEOUT_MS=300000
 JWT_SIGNING_KEY=<your-secret-key-for-jwt-signing>
 TOKEN_ENCRYPTION_KEY=<32-byte-hex-key-for-token-encryption>
 ```
@@ -95,6 +95,29 @@ npm run dev:http
 
 ```bash
 npm run build && npm start
+```
+
+### Logging
+
+The server emits one structured JSON log line per event to **stderr** (stdout is reserved for the MCP stdio protocol). Logging is **on by default**; set `MCP_LOG=0` to disable it.
+
+Events:
+
+| `event` | When | Key fields |
+|---------|------|------------|
+| `tool_call` | LLM invokes a tool | `reqId`, `tool`, `input` (raw args from the LLM) |
+| `api_request` | Outbound call to Generect API | `url`, `method`, `body` (filter payload; never the token) |
+| `api_response` | Generect API responded | `url`, `status`, `ms` |
+| `tool_result` | Result returned to the LLM | `reqId`, `tool`, `ms`, `output` (text/structuredContent preview) |
+| `tool_error` / `api_error` | Failure | `reqId`/`url`, `error`, `ms` |
+
+`reqId` correlates a `tool_call` with its `tool_result`. Set `MCP_DEBUG=1` for additional verbose output.
+
+View logs on the deployed container:
+
+```bash
+docker logs -f <mcp-container>                 # live
+docker logs <mcp-container> | grep tool_call   # only LLM inputs
 ```
 
 ### Tools
@@ -116,7 +139,7 @@ npm run build && npm start
       "env": {
         "GENERECT_API_BASE": "https://api.generect.com",
         "GENERECT_API_KEY": "Token YOUR_API_KEY",
-        "GENERECT_TIMEOUT_MS": "60000"
+        "GENERECT_TIMEOUT_MS": "300000"
       }
     }
   }
@@ -136,7 +159,7 @@ Add to `~/.claude/claude_desktop_config.json` (or via UI → MCP Servers). Recom
       "env": {
         "GENERECT_API_BASE": "https://api.generect.com",
         "GENERECT_API_KEY": "Token YOUR_API_KEY",
-        "GENERECT_TIMEOUT_MS": "60000",
+        "GENERECT_TIMEOUT_MS": "300000",
         "MCP_DEBUG": "0"
       }
     }
@@ -204,7 +227,7 @@ Some MCP clients allow spawning the server via SSH, using stdio over the SSH ses
       "env": {
         "GENERECT_API_BASE": "https://api.generect.com",
         "GENERECT_API_KEY": "Token YOUR_API_KEY",
-        "GENERECT_TIMEOUT_MS": "60000"
+        "GENERECT_TIMEOUT_MS": "300000"
       }
     }
   }

--- a/scripts/verify-logging.mjs
+++ b/scripts/verify-logging.mjs
@@ -1,0 +1,91 @@
+// Самопроверка логирования MCP-сервера.
+//
+// Что делает: поднимает ФЕЙКОВЫЙ Generect API на localhost, запускает НАСТОЯЩИЙ
+// MCP-сервер (dist/server.js) против него и шлёт ему такие же запросы, какие шлёт
+// LLM. Реальный API-ключ НЕ нужен — ничего наружу не уходит.
+//
+// Запуск:
+//   npm run build            # один раз, чтобы собрать dist/
+//   node scripts/verify-logging.mjs
+//
+// Что ты должен увидеть: на каждый вызов инструмента — 4 строки лога
+// (tool_call -> api_request -> api_response -> tool_result). Это и есть
+// "что LLM прислала на вход" и "что мы вернули в LLM".
+
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// 1. Фейковый Generect API. Записывает, что MCP-сервер ему прислал, и отвечает.
+const received = [];
+const mock = http.createServer((req, res) => {
+  let body = '';
+  req.on('data', (c) => (body += c));
+  req.on('end', () => {
+    received.push({ path: req.url, auth: req.headers['authorization'], body: JSON.parse(body || '{}') });
+    res.setHeader('content-type', 'application/json');
+    if (req.url.includes('/leads/by_icp/')) {
+      res.end(JSON.stringify({ amount: 1, leads: [{ full_name: 'Ada Lovelace', job_title: 'CTO', company_name: 'Analytical Co', company_industry: 'Software', location: 'United States', linkedin_url: 'https://linkedin.com/in/ada' }] }));
+    } else if (req.url.includes('/companies/by_icp/')) {
+      res.end(JSON.stringify({ amount: 1, companies: [{ name: 'Analytical Co', website: 'analytical.co', headcount_range: '11-50', industry: 'Software', location: 'United States' }] }));
+    } else {
+      res.statusCode = 404;
+      res.end('{}');
+    }
+  });
+});
+
+await new Promise((r) => mock.listen(0, r));
+const base = `http://127.0.0.1:${mock.address().port}`;
+
+// 2. Настоящий MCP-сервер, направленный на фейковый API, с фиктивным ключом.
+const srv = spawn('node', ['dist/server.js'], {
+  cwd: root,
+  env: { ...process.env, GENERECT_API_BASE: base, GENERECT_API_KEY: 'dummy-key-not-real', MCP_LOG: '1' },
+});
+
+let logs = '';
+srv.stderr.on('data', (d) => (logs += d)); // логи сервера идут в stderr
+const send = (o) => srv.stdin.write(JSON.stringify(o) + '\n');
+
+// 3. Имитируем клиента (LLM): рукопожатие + два вызова инструментов.
+send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'verify', version: '1' } } });
+send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+setTimeout(() => send({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'search_leads', arguments: { job_title: 'CTO', locations: ['United States'], lead_industries: ['Software'], limit_by: 5 } } }), 300);
+setTimeout(() => send({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'search_companies', arguments: { industries: ['Software'], headcounts: ['11-50'], locations: ['United States'] } } }), 700);
+
+// 4. Печатаем результат с подписями.
+setTimeout(() => {
+  const lines = logs.trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+  const human = {
+    tool_call: 'ВХОД  — что LLM прислала инструменту',
+    api_request: 'ИСХОД — что мы отправили в Generect API (без токена!)',
+    api_response: 'ОТВЕТ — статус и время ответа API',
+    tool_result: 'ВЫХОД — что вернули обратно в LLM',
+    tool_error: 'ОШИБКА инструмента',
+    api_error: 'ОШИБКА запроса к API',
+  };
+  console.log('\n================= ЛОГИ MCP-СЕРВЕРА =================\n');
+  for (const l of lines) {
+    console.log(`[${human[l.event] || l.event}]  reqId=${l.reqId ?? '-'}`);
+    console.log('   ' + JSON.stringify(l));
+    console.log('');
+  }
+
+  const ok =
+    lines.some((l) => l.event === 'tool_call' && l.input?.job_title === 'CTO') &&
+    lines.some((l) => l.event === 'api_request' && l.body?.personas) &&
+    lines.some((l) => l.event === 'tool_result' && /Ada Lovelace/.test(JSON.stringify(l.output)));
+
+  console.log('================= ИТОГ =================');
+  console.log(ok ? '✅ OK: вход и выход LLM логируются, запрос доходит до API.' : '❌ Что-то не так — логов неполный набор.');
+  console.log('\nДля справки — что фейковый API реально получил от MCP-сервера:');
+  console.log(JSON.stringify(received, null, 2));
+
+  srv.kill();
+  mock.close();
+  process.exit(ok ? 0 : 1);
+}, 1600);

--- a/scripts/verify-timeout.mjs
+++ b/scripts/verify-timeout.mjs
@@ -1,0 +1,70 @@
+// Самопроверка таймаута MCP-сервера.
+//
+// Поднимает МЕДЛЕННЫЙ фейковый API (отвечает через 2 секунды) и проверяет:
+//   1) с дефолтным таймаутом (300с) запрос УСПЕВАЕТ — ответ приходит;
+//   2) если выставить GENERECT_TIMEOUT_MS=1000 (1с) — запрос ОБРЫВАЕТСЯ по таймауту.
+// Это доказывает, что таймаут реально читается из окружения и работает.
+//
+// Запуск:  npm run build && node scripts/verify-timeout.mjs
+
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DELAY_MS = 2000; // фейковый API "думает" 2 секунды
+
+function startMock() {
+  const mock = http.createServer((req, res) => {
+    setTimeout(() => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ amount: 1, leads: [{ full_name: 'Slow Lead', linkedin_url: 'https://x' }] }));
+    }, DELAY_MS);
+  });
+  return new Promise((r) => mock.listen(0, () => r(mock)));
+}
+
+// Один прогон: вызывает search_leads и возвращает текст результата, отданный в LLM.
+function runOnce(base, timeoutEnv) {
+  return new Promise((resolveRun) => {
+    const env = { ...process.env, GENERECT_API_BASE: base, GENERECT_API_KEY: 'dummy', MCP_LOG: '0' };
+    if (timeoutEnv != null) env.GENERECT_TIMEOUT_MS = String(timeoutEnv);
+    const p = spawn('node', ['dist/server.js'], { cwd: root, env });
+    let out = '';
+    p.stdout.on('data', (d) => (out += d));
+    const send = (o) => p.stdin.write(JSON.stringify(o) + '\n');
+    send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } } });
+    send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    setTimeout(() => send({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'search_leads', arguments: { job_title: 'CTO' } } }), 300);
+    setTimeout(() => {
+      const lines = out.trim().split('\n').filter(Boolean).map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+      const r = lines.find((l) => l.id === 2);
+      p.kill();
+      resolveRun(r?.result?.content?.[0]?.text ?? '(нет ответа)');
+    }, DELAY_MS + 2000);
+  });
+}
+
+const mock = await startMock();
+const base = `http://127.0.0.1:${mock.address().port}`;
+
+console.log(`Фейковый API отвечает за ${DELAY_MS} мс.\n`);
+
+console.log('1) Дефолтный таймаут (300с) — должен УСПЕТЬ:');
+const ok = await runOnce(base, undefined);
+const passed1 = /Slow Lead/.test(ok);
+console.log('   ' + ok.replace(/\n/g, ' ').slice(0, 120));
+console.log('   => ' + (passed1 ? '✅ ответ получен' : '❌ не получен'));
+
+console.log('\n2) Короткий таймаут GENERECT_TIMEOUT_MS=1000 (1с) — должен ОБОРВАТЬСЯ:');
+const aborted = await runOnce(base, 1000);
+const passed2 = /AbortError|aborted/i.test(aborted);
+console.log('   ' + aborted.replace(/\n/g, ' ').slice(0, 160));
+console.log('   => ' + (passed2 ? '✅ оборвался по таймауту (значит env читается)' : '❌ не оборвался'));
+
+console.log('\n================= ИТОГ =================');
+console.log(passed1 && passed2 ? '✅ Таймаут работает и управляется через GENERECT_TIMEOUT_MS.' : '❌ Что-то не так.');
+
+mock.close();
+process.exit(passed1 && passed2 ? 0 : 1);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,11 +1,68 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
 import { verifyAccessToken, extractApiToken } from './auth/jwt.js';
 import { parseAuthHeader } from './auth/parse.js';
 
-const debug = process.env.MCP_DEBUG === '1' || process.env.MCP_DEBUG === 'true';
+// Structured request/response logging is ON by default; set MCP_LOG=0 to disable.
+const logEnabled = process.env.MCP_LOG !== '0' && process.env.MCP_LOG !== 'false';
 
 type Fetcher = typeof fetch;
+
+// One JSON line per event, written to stderr (stdout is reserved for the MCP
+// stdio protocol, so logs must never go there). Captures what the LLM sends in
+// and what it gets back, correlated by reqId.
+function logEvent(event: string, data: Record<string, unknown>) {
+  if (!logEnabled) return;
+  try {
+    console.error(JSON.stringify({ ts: new Date().toISOString(), event, ...data }));
+  } catch {
+    console.error(`[mcp] ${event}`, data);
+  }
+}
+
+// Pull a readable preview of what is returned to the LLM out of an MCP result.
+function previewResult(result: any) {
+  try {
+    const text = result?.content?.map((c: any) => (typeof c?.text === 'string' ? c.text : '')).join('\n');
+    const out: Record<string, unknown> = {};
+    if (text) out.text = text.length > 4000 ? `${text.slice(0, 4000)}…(${text.length} chars)` : text;
+    if (result?.structuredContent) out.structuredContent = result.structuredContent;
+    if (result?.isError) out.isError = true;
+    return Object.keys(out).length ? out : result;
+  } catch {
+    return result;
+  }
+}
+
+// Wraps a tool handler so every call logs the input (LLM → tool) and the
+// output (tool → LLM) with timing, under a shared request id.
+function loggedTool(
+  server: McpServer,
+  name: string,
+  description: string,
+  schema: any,
+  handler: (args: any, extra: any) => Promise<any>,
+) {
+  server.tool(name, description, schema, async (args: any, extra: any) => {
+    const reqId = randomUUID();
+    const started = Date.now();
+    logEvent('tool_call', { reqId, tool: name, input: args });
+    try {
+      const result = await handler(args, extra);
+      logEvent('tool_result', {
+        reqId,
+        tool: name,
+        ms: Date.now() - started,
+        output: previewResult(result),
+      });
+      return result;
+    } catch (err: unknown) {
+      logEvent('tool_error', { reqId, tool: name, ms: Date.now() - started, error: String(err) });
+      throw err;
+    }
+  });
+}
 
 function jsonTextContent(value: unknown) {
   return {
@@ -39,18 +96,78 @@ function sanitizeCompany(company: any) {
 }
 
 async function fetchWithTimeout(fetcher: Fetcher, url: string, init: RequestInit, timeoutMs = 20000) {
-  if (debug) {
-    const body = init.body?.toString() || null;
-    console.error(`[mcp] doint request to ${url} with ${body}`);
-  }
+  // Log the exact filter payload we forward to the Generect API (never the
+  // Authorization header — it carries the API token).
+  let reqBody: unknown = init.body?.toString() || null;
+  try {
+    if (typeof reqBody === 'string') reqBody = JSON.parse(reqBody);
+  } catch {}
+  logEvent('api_request', { url, method: init.method ?? 'GET', body: reqBody });
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), timeoutMs);
+  const started = Date.now();
   try {
     const res = await fetcher(url, { ...init, signal: controller.signal });
+    // On a non-2xx response, capture the API error body (clone so the caller can
+    // still read the stream). This is what reveals *why* a filter was rejected
+    // instead of the rejection silently surfacing to the LLM as "0 results".
+    let errorBody: string | undefined;
+    if (!res.ok) {
+      try {
+        const t = await res.clone().text();
+        errorBody = t.length > 2000 ? `${t.slice(0, 2000)}…(${t.length} chars)` : t;
+      } catch {}
+    }
+    logEvent('api_response', { url, status: res.status, ms: Date.now() - started, ...(errorBody ? { errorBody } : {}) });
     return res;
+  } catch (err: unknown) {
+    logEvent('api_error', { url, ms: Date.now() - started, error: String(err) });
+    throw err;
   } finally {
     clearTimeout(id);
   }
+}
+
+// Calls the Generect API and parses JSON. On a non-2xx status it throws an error
+// carrying the real API status + detail, so a rejected filter surfaces to the LLM
+// as an actual error instead of being silently flattened to "0 results".
+async function callApi(fetcher: Fetcher, url: string, init: RequestInit, timeoutMs: number) {
+  const res = await fetchWithTimeout(fetcher, url, init, timeoutMs);
+  const text = await res.text();
+  let data: any = text;
+  try {
+    data = JSON.parse(text);
+  } catch {}
+  if (!res.ok) {
+    const err: any = new Error(`Generect API responded with ${res.status}`);
+    err.status = res.status;
+    err.detail = data && typeof data === 'object' && 'detail' in data ? data.detail : data;
+    throw err;
+  }
+  return data;
+}
+
+// Builds an MCP error result the LLM can act on (real status + reason), flagged
+// with isError so clients don't treat it as a successful empty payload.
+function apiError(err: any) {
+  return {
+    ...jsonTextContent({
+      error: String(err?.message ?? err),
+      status: err?.status ?? null,
+      detail: err?.detail ?? null,
+    }),
+    isError: true,
+  } as any;
+}
+
+// MCP-internal control flags that must not be forwarded to the Generect API as
+// if they were search filters. `limit`/`offset` are accepted as friendly aliases
+// and mapped to the API's `limit_by`/`offset_by`.
+function toApiFilters(args: any) {
+  const { compact, timeout_ms, fallback_from_leads, limit, offset, ...filters } = args ?? {};
+  if (limit != null && filters.limit_by == null) filters.limit_by = limit;
+  if (offset != null && filters.offset_by == null) filters.offset_by = offset;
+  return filters as Record<string, unknown>;
 }
 
 export function registerTools(server: McpServer, fetcher: Fetcher, apiBase: string, apiKey: string) {
@@ -76,48 +193,51 @@ export function registerTools(server: McpServer, fetcher: Fetcher, apiBase: stri
     }
     return `Token ${extractApiToken(payload)}`;
   }
-  const defaultTimeoutMs = Number(process.env.GENERECT_TIMEOUT_MS || '160000');
-  const debug = process.env.MCP_DEBUG === '1' || process.env.MCP_DEBUG === 'true';
+  const defaultTimeoutMs = Number(process.env.GENERECT_TIMEOUT_MS || '300000');
 
   // 1. Search leads by ICP
-  server.tool(
+  loggedTool(
+    server,
     'search_leads',
     'Search for leads by ICP filters',
     {
       job_title: z.string().describe('Job title filter (e.g., CEO, CTO, Engineer)').optional(),
-      locations: z.array(z.string()).describe('Location filter (e.g., San Francisco, New York)').optional(),
-      lead_industries: z.array(z.string()).describe('Industry filter (e.g., Technology, Healthcare)').optional(),
+      locations: z
+        .array(z.string())
+        .describe('Location filter — country or region names, e.g. ["United States", "Canada"]')
+        .optional(),
+      lead_industries: z
+        .array(z.string())
+        .describe('Industry filter. Must match Generect industry names exactly (e.g. "Information Technology and Services", "Financial Services"). Invalid names are rejected by the API.')
+        .optional(),
       company_id: z.string().describe('LinkedIn company id').optional(),
       company_link: z.string().describe('LinkedIn company URL').optional(),
       company_name: z.string().describe('Company name').optional(),
       limit_by: z.number().describe('Number of results to return').optional(),
       offset_by: z.number().describe('Offset for pagination').optional(),
-      without_company: z.boolean().describe('Search leads without filrest by companies').optional(),
+      limit: z.number().describe('Alias for limit_by').optional(),
+      offset: z.number().describe('Alias for offset_by').optional(),
+      without_company: z.boolean().describe('Search leads without filtering by companies').optional(),
       compact: z.boolean().describe('Return compact summary instead of full JSON').optional(),
       timeout_ms: z.number().describe('Request timeout in milliseconds').optional(),
     },
     async (args, extra) => {
-      if (debug) console.error('[mcp] search_leads args:', JSON.stringify(args));
-
-      const body: typeof args & { personas?: any[] } = args;
-      if (args.job_title) {
-        body['personas'] = [[args.job_title, [args.job_title.toLowerCase()], [], []]];
-      }
-
       try {
         const Authorization = await resolveAuthHeader(extra);
-        const res = await fetchWithTimeout(
+        const apiBody = toApiFilters(args);
+        if (args.job_title) {
+          apiBody.personas = [[args.job_title, [args.job_title.toLowerCase()], [], []]];
+        }
+        const data = await callApi(
           fetcher,
           `${apiBase}/api/linkedin/leads/by_icp/`,
           {
             method: 'POST',
             headers: { Authorization, 'Content-Type': 'application/json' },
-            body: JSON.stringify(args || {}),
+            body: JSON.stringify(apiBody),
           },
           Number(args?.timeout_ms ?? defaultTimeoutMs),
         );
-        const text = await res.text();
-        const data = JSON.parse(text);
         const compact = args?.compact !== false;
         if (compact && data) {
           const leads = (data.leads ?? data.results ?? data.items ?? []) as any[];
@@ -137,45 +257,53 @@ export function registerTools(server: McpServer, fetcher: Fetcher, apiBase: stri
         }
         return jsonTextContent(data);
       } catch (err: unknown) {
-        return jsonTextContent({ error: String(err) });
+        return apiError(err);
       }
     },
   );
 
   // 2. Search companies
-  server.tool(
+  loggedTool(
+    server,
     'search_companies',
     'Search for companies by ICP filters',
     {
-      company_types: z.array(z.string()).describe('Company types').optional(),
+      company_types: z
+        .array(z.string())
+        .describe('Company types. Allowed values: "Public Company", "Educational", "Self Employed", "Government Agency", "Non Profit", "Self Owned", "Privately Held", "Partnership".')
+        .optional(),
       get_max_companies: z.boolean().describe('Get maximum companies').optional(),
-      headcounts: z.array(z.string()).describe('Headcount ranges').optional(),
-      industries: z.array(z.string()).describe('Industries').optional(),
-      locations: z.array(z.string()).describe('Locations (Countries, e.g "United States")').optional(),
+      headcounts: z
+        .array(z.string())
+        .describe('Employee headcount ranges. Allowed values ONLY: "1", "2-10", "11-50", "51-200", "201-500", "501-1000", "1001-5000", "5001-10000", "10000+". Note the largest bucket is "10000+" (NOT "10001+").')
+        .optional(),
+      industries: z
+        .array(z.string())
+        .describe('Industries. Must match Generect industry names exactly (e.g. "Software Development", "Financial Services"). Invalid names are rejected by the API.')
+        .optional(),
+      locations: z.array(z.string()).describe('Locations (countries, e.g. ["United States"])').optional(),
       keywords: z.array(z.string()).describe('Keywords').optional(),
       limit_by: z.number().describe('Number of results to return').optional(),
       offset_by: z.number().describe('Offset for pagination').optional(),
+      limit: z.number().describe('Alias for limit_by').optional(),
+      offset: z.number().describe('Alias for offset_by').optional(),
       compact: z.boolean().describe('Return compact summary instead of full JSON').optional(),
       fallback_from_leads: z.boolean().describe('If no companies, derive from leads by keywords').optional(),
       timeout_ms: z.number().describe('Request timeout in milliseconds').optional(),
     },
     async (args, extra) => {
-      if (debug) console.error('[mcp] search_companies args:', JSON.stringify(args));
-
       try {
         const Authorization = await resolveAuthHeader(extra);
-        const res = await fetchWithTimeout(
+        let data = await callApi(
           fetcher,
           `${apiBase}/api/linkedin/companies/by_icp/`,
           {
             method: 'POST',
             headers: { Authorization, 'Content-Type': 'application/json' },
-            body: JSON.stringify(args || {}),
+            body: JSON.stringify(toApiFilters(args)),
           },
           Number(args?.timeout_ms ?? defaultTimeoutMs),
         );
-        const text = await res.text();
-        let data = JSON.parse(text);
         const companiesEmpty = !data || !Array.isArray(data.companies) || data.companies.length === 0;
         const shouldFallback =
           companiesEmpty &&
@@ -185,21 +313,21 @@ export function registerTools(server: McpServer, fetcher: Fetcher, apiBase: stri
         if (shouldFallback) {
           const leadsBody: Record<string, unknown> = {
             keywords: args.keywords,
-            limit: 100,
+            limit_by: 100,
           };
-          const resLeads = await fetchWithTimeout(
-            fetcher,
-            `${apiBase}/api/linkedin/leads/by_icp/`,
-            {
-              method: 'POST',
-              headers: { Authorization, 'Content-Type': 'application/json' },
-              body: JSON.stringify(leadsBody),
-            },
-            Number(args?.timeout_ms ?? defaultTimeoutMs),
-          );
-          const leadsText = await resLeads.text();
+          // Best-effort fallback: if the leads lookup itself fails, keep the
+          // (empty) company result rather than turning it into an error.
           try {
-            const leadsData = JSON.parse(leadsText);
+            const leadsData = await callApi(
+              fetcher,
+              `${apiBase}/api/linkedin/leads/by_icp/`,
+              {
+                method: 'POST',
+                headers: { Authorization, 'Content-Type': 'application/json' },
+                body: JSON.stringify(leadsBody),
+              },
+              Number(args?.timeout_ms ?? defaultTimeoutMs),
+            );
             const leads = (leadsData.leads ?? leadsData.results ?? []) as any[];
             const counts = new Map<string, number>();
             for (const lead of leads) {
@@ -239,13 +367,14 @@ export function registerTools(server: McpServer, fetcher: Fetcher, apiBase: stri
         }
         return jsonTextContent(data);
       } catch (err: unknown) {
-        return jsonTextContent({ error: String(err) });
+        return apiError(err);
       }
     },
   );
 
   // 3. Email finder
-  server.tool(
+  loggedTool(
+    server,
     'generate_email',
     'Generate email by first/last name and domain via Generect Email Generator',
     {
@@ -255,7 +384,6 @@ export function registerTools(server: McpServer, fetcher: Fetcher, apiBase: stri
       timeout_ms: z.number().describe('Request timeout in milliseconds').optional(),
     },
     async (args, extra) => {
-      if (debug) console.error('[mcp] generate_email args:', JSON.stringify(args));
       try {
         const Authorization = await resolveAuthHeader(extra);
         const candidate = {
@@ -263,7 +391,7 @@ export function registerTools(server: McpServer, fetcher: Fetcher, apiBase: stri
           last_name: args.last_name,
           domain: args.domain,
         };
-        const res = await fetchWithTimeout(
+        const data = await callApi(
           fetcher,
           `${apiBase}/api/linkedin/email_finder/`,
           {
@@ -273,16 +401,16 @@ export function registerTools(server: McpServer, fetcher: Fetcher, apiBase: stri
           },
           Number(args?.timeout_ms ?? defaultTimeoutMs),
         );
-        const text = await res.text();
-        return jsonTextContent(JSON.parse(text));
+        return jsonTextContent(data);
       } catch (err: unknown) {
-        return jsonTextContent({ error: String(err) });
+        return apiError(err);
       }
     },
   );
 
   // 4. Get lead by LinkedIn URL
-  server.tool(
+  loggedTool(
+    server,
     'get_lead_by_url',
     'Get Lead by LinkedIn URL',
     {
@@ -294,7 +422,6 @@ export function registerTools(server: McpServer, fetcher: Fetcher, apiBase: stri
       timeout_ms: z.number().describe('Request timeout in milliseconds').optional(),
     },
     async (args: any, extra: any) => {
-      if (debug) console.error('[mcp] get_lead_by_url args:', JSON.stringify(args));
       try {
         const Authorization = await resolveAuthHeader(extra);
         const payload = {
@@ -304,7 +431,7 @@ export function registerTools(server: McpServer, fetcher: Fetcher, apiBase: stri
           people_also_viewed: Boolean(args.people_also_viewed),
           posts: Boolean(args.posts),
         };
-        const res = await fetchWithTimeout(
+        const data = await callApi(
           fetcher,
           `${apiBase}/api/linkedin/leads/by_link/`,
           {
@@ -314,16 +441,16 @@ export function registerTools(server: McpServer, fetcher: Fetcher, apiBase: stri
           },
           Number(args?.timeout_ms ?? defaultTimeoutMs),
         );
-        const text = await res.text();
-        return jsonTextContent(JSON.parse(text));
+        return jsonTextContent(data);
       } catch (err: unknown) {
-        return jsonTextContent({ error: String(err) });
+        return apiError(err);
       }
     },
   );
 
   // 5. Health check
-  server.tool(
+  loggedTool(
+    server,
     'health',
     'Health check Generect API via a quick lead-by-link request',
     {
@@ -331,7 +458,6 @@ export function registerTools(server: McpServer, fetcher: Fetcher, apiBase: stri
       timeout_ms: z.number().describe('Request timeout in milliseconds').optional(),
     },
     async (args, extra) => {
-      if (debug) console.error('[mcp] health args:', JSON.stringify(args));
       const started = Date.now();
       const testUrl =
         typeof args?.url === 'string' && args.url.trim() ? args.url : 'https://www.linkedin.com/in/satyanadella/';


### PR DESCRIPTION
## What & why

Adds logging of MCP requests so we can see **what the LLM sends in and what it gets back**, and fixes issues that logging immediately surfaced against the live API.

### Logging (the main ask)
Structured JSON, one line per event, to **stderr** (stdout is reserved for the MCP stdio protocol). On by default; disable with `MCP_LOG=0`.

| event | meaning |
|---|---|
| `tool_call` | raw args the LLM sent (input) |
| `api_request` | payload forwarded to Generect API (token redacted) |
| `api_response` | status + ms (+ error body on non-2xx) |
| `tool_result` | what we return to the LLM (output) |
| `tool_error` / `api_error` | failures |

Correlated by `reqId`. View in prod: `docker logs -f <container>`.

### Filter-interpretation fixes (found via these logs)
- **Rejected filters no longer masked as "0 results".** `callApi()` checks `res.ok` and returns the real API error to the LLM as `isError` with `status` + `detail`. Previously a `400` (e.g. invalid `headcounts`) was flattened to `{amount: 0}`, so the LLM thought "nothing matched" instead of "filter invalid".
- **Document allowed filter values** in the tool schemas: `headcounts` (`"1" … "10000+"` — note the largest bucket is `"10000+"`, the API rejects `"10001+"`), `company_types`, and a note that industry/location names must match exactly.
- **Accept `limit`/`offset`** as aliases for `limit_by`/`offset_by` (the LLM/clients commonly send `limit`, which was silently dropped).
- **Stop leaking MCP-internal flags** (`compact`, `timeout_ms`, `fallback_from_leads`) into the API request body.

### Timeout
- Default `GENERECT_TIMEOUT_MS` raised `60000` → `300000` (searches routinely take >60s). Changed in `tools.ts`, `Dockerfile`, README.
- ⚠️ **Infra dependency:** the prod nginx in front of `mcp.generect.com` has its own `proxy_read_timeout` (default 60s). It must be raised to `300s` server-side, otherwise the app-level timeout won't take effect through the proxy.

## Testing
`npm run build` is clean. Two reproducible helpers run the real server against a mock API:
- `node scripts/verify-logging.mjs` — confirms input/output logging end to end
- `node scripts/verify-timeout.mjs` — confirms the timeout is honored and env-controlled

Verified: all 5 tools register; happy paths; `limit` alias → `limit_by`; internal flags stripped; `personas` injection; **400 → `isError` with reason (not "0 results")**; timeout behavior. Also confirmed live against `api.generect.com`.

## Notes for reviewers
- Can split the timeout bump into its own PR if you'd prefer to decide it separately.
- The `scripts/verify-*.mjs` helpers are ad-hoc (mock-based), not a formal test runner — easy to drop if unwanted.